### PR TITLE
Add tablet tasks page

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -100,5 +100,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/angular.json
+++ b/angular.json
@@ -100,8 +100,5 @@
         }
       }
     }
-  },
-  "cli": {
-    "analytics": false
   }
 }

--- a/angular.json
+++ b/angular.json
@@ -20,18 +20,12 @@
             "outputPath": "dist/tech-plain",
             "index": "src/index.html",
             "main": "src/main.ts",
-            "polyfills": [
-              "zone.js"
-            ],
+            "baseHref": "/tech-plain/",
+            "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
             "scripts": []
           },
           "configurations": {
@@ -48,7 +42,12 @@
                   "maximumError": "4kb"
                 }
               ],
-              "outputHashing": "all"
+              "outputHashing": "none",
+              "buildOptimizer": true,
+              "optimization": true,
+              "extractLicenses": true,
+              "sourceMap": false,
+              "namedChunks": false
             },
             "development": {
               "buildOptimizer": false,
@@ -82,19 +81,11 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "polyfills": [
-              "zone.js",
-              "zone.js/testing"
-            ],
+            "polyfills": ["zone.js", "zone.js/testing"],
             "tsConfig": "tsconfig.spec.json",
             "inlineStyleLanguage": "scss",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
             "scripts": []
           }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@angular/compiler": "^16.2.0",
         "@angular/core": "^16.2.0",
         "@angular/forms": "^16.2.0",
+        "@angular/material": "^16.2.0",
         "@angular/platform-browser": "^16.2.0",
         "@angular/platform-browser-dynamic": "^16.2.0",
         "@angular/router": "^16.2.0",
@@ -573,6 +574,71 @@
         "@angular/common": "16.2.12",
         "@angular/core": "16.2.12",
         "@angular/platform-browser": "16.2.12",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/material": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-16.2.0.tgz",
+      "integrity": "sha512-TMcg7zDZy3Q9KA2tCiBqXsjDMO+V7IWmFewPruX9NH5BTT6aZwfKxbFbJgRzhJgok4wJA4IIN5Jt4pPOKQ9LzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/auto-init": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/banner": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/card": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/checkbox": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/chips": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/circular-progress": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/data-table": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dialog": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/drawer": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/fab": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/floating-label": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/form-field": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/icon-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/image-list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/layout-grid": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/line-ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/linear-progress": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu-surface": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/notched-outline": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/radio": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/segmented-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/select": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/slider": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/snackbar": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/switch": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-bar": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-scroller": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/textfield": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tooltip": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/top-app-bar": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": "^16.0.0 || ^17.0.0",
+        "@angular/cdk": "16.2.0",
+        "@angular/common": "^16.0.0 || ^17.0.0",
+        "@angular/core": "^16.0.0 || ^17.0.0",
+        "@angular/forms": "^16.0.0 || ^17.0.0",
+        "@angular/platform-browser": "^16.0.0 || ^17.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -3011,6 +3077,808 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "dev": true
+    },
+    "node_modules/@material/animation": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-leRf+BcZTfC/iSigLXnYgcHAGvFVQveoJT5+2PIRdyPI/bIG7hhciRgacHRsCKC0sGya81dDblLgdkjSUemYLw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/auto-init": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/auto-init/-/auto-init-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-uxzDq7q3c0Bu1pAsMugc1Ik9ftQYQqZY+5e2ybNplT8gTImJhNt4M2mMiMHbMANk2l3UgICmUyRSomgPBWCPIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/banner": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/banner/-/banner-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-SHeVoidCUFVhXANN6MNWxK9SZoTSgpIP8GZB7kAl52BywLxtV+FirTtLXkg/8RUkxZRyRWl7HvQ0ZFZa7QQAyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/base": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Fc3vGuOf+duGo22HTRP6dHdc+MUe0VqQfWOuKrn/wXKD62m0QQR2TqJd3rRhCumH557T5QUyheW943M3E+IGfg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/button": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/button/-/button-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-3AQgwrPZCTWHDJvwgKq7Cj+BurQ4wTjDdGL+FEnIGUAjJDskwi1yzx5tW2Wf/NxIi7IoPFyOY3UB41jwMiOrnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/card": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/card/-/card-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-nPlhiWvbLmooTnBmV5gmzB0eLWSgLKsSRBYAbIBmO76Okgz1y+fQNLag+lpm/TDaHVsn5fmQJH8e0zIg0rYsQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/checkbox": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/checkbox/-/checkbox-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-4tpNnO1L0IppoMF3oeQn8F17t2n0WHB0D7mdJK9rhrujen/fLbekkIC82APB3fdGtLGg3qeNqDqPsJm1YnmrwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/chips": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/chips/-/chips-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-fqHKvE5bSWK0bXVkf57MWxZtytGqYBZvvHIOs4JI9HPHEhaJy4CpSw562BEtbm3yFxxALoQknvPW2KYzvADnmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/checkbox": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "safevalues": "^0.3.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/circular-progress": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/circular-progress/-/circular-progress-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Lxe8BGAxQwCQqrLhrYrIP0Uok10h7aYS3RBXP41ph+5GmwJd5zdyE2t93qm2dyThvU6qKuXw9726Dtq/N+wvZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/progress-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/data-table": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/data-table/-/data-table-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-j/7qplT9+sUpfe4pyWhPbl01qJA+OoNAG3VMJruBBR461ZBKyTi7ssKH9yksFGZ8eCEPkOsk/+kDxsiZvRWkeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/checkbox": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/icon-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/linear-progress": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/select": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/density": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/density/-/density-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Zt3u07fXrBWLW06Tl5fgvjicxNQMkFdawLyNTzZ5TvbXfVkErILLePwwGaw8LNcvzqJP6ABLA8jiR+sKNoJQCg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/dialog": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/dialog/-/dialog-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-o+9a/fmwJ9+gY3Z/uhj/PMVJDq7it1NTWKJn2GwAKdB+fDkT4hb9qEdcxMPyvJJ5ups+XiKZo03+tZrD+38c1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/icon-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/dom": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-ly78R7aoCJtundSUu0UROU+5pQD5Piae0Y1MkN6bs0724azeazX1KeXFeaf06JOXnlr5/41ol+fSUPowjoqnOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/drawer": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/drawer/-/drawer-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-PFL4cEFnt7VTxDsuspFVNhsFDYyumjU0VWfj3PWB7XudsEfQ3lo85D3HCEtTTbRsCainGN8bgYNDNafLBqiigw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/elevation": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Ro+Pk8jFuap+T0B0shA3xI1hs2b89dNQ2EIPCNjNMp87emHKAzJfhKb7EZGIwv3+gFLlVaLyIVkb94I89KLsyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/fab": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/fab/-/fab-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-dvU0KWMRglwJEQwmQtFAmJcAjzg9VFF6Aqj78bJYu/DAIGFJ1VTTTSgoXM/XCm1YyQEZ7kZRvxBO37CH54rSDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/feature-targeting": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-wkDjVcoVEYYaJvun28IXdln/foLgPD7n9ZC9TY76GErGCwTq+HWpU6wBAAk+ePmpRFDayw4vI4wBlaWGxLtysQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/floating-label": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/floating-label/-/floating-label-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-bUWPtXzZITOD/2mkvLkEPO1ngDWmb74y0Kgbz6llHLOQBtycyJIpuoQJ1q2Ez0NM/tFLwPphhAgRqmL3YQ/Kzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/focus-ring": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/focus-ring/-/focus-ring-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-cZHThVose3GvAlJzpJoBI1iqL6d1/Jj9hXrR+r8Mwtb1hBIUEG3hxfsRd4vGREuzROPlf0OgNf/V+YHoSwgR5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0"
+      }
+    },
+    "node_modules/@material/form-field": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/form-field/-/form-field-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-+JFXy5X44Gue1CbZZAQ6YejnI203lebYwL0i6k0ylDpWHEOdD5xkF2PyHR28r9/65Ebcbwbff6q7kI1SGoT7MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/icon-button": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/icon-button/-/icon-button-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-1a0MHgyIwOs4RzxrVljsqSizGYFlM1zY2AZaLDsgT4G3kzsplTx8HZQ022GpUCjAygW+WLvg4z1qAhQHvsbqlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/image-list": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/image-list/-/image-list-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-WKWmiYap2iu4QdqmeUSliLlN4O2Ueqa0OuVAYHn/TCzmQ2xmnhZ1pvDLbs6TplpOmlki7vFfe+aSt5SU9gwfOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/layout-grid": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/layout-grid/-/layout-grid-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-5GqmT6oTZhUGWIb+CLD0ZNyDyTiJsr/rm9oRIi3+vCujACwxFkON9tzBlZohdtFS16nuzUusthN6Jt9UrJcN6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/line-ripple": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/line-ripple/-/line-ripple-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-8S30WXEuUdgDdBulzUDlPXD6qMzwCX9SxYb5mGDYLwl199cpSGdXHtGgEcCjokvnpLhdZhcT1Dsxeo1g2Evh5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/linear-progress": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/linear-progress/-/linear-progress-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-6EJpjrz6aoH2/gXLg9iMe0yF2C42hpQyZoHpmcgTLKeci85ktDvJIjwup8tnk8ULQyFiGiIrhXw2v2RSsiFjvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/progress-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/list": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/list/-/list-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-TQ1ppqiCMQj/P7bGD4edbIIv4goczZUoiUAaPq/feb1dflvrFMzYqJ7tQRRCyBL8nRhJoI2x99tk8Q2RXvlGUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/menu": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/menu/-/menu-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-IlAh61xzrzxXs38QZlt74UYt8J431zGznSzDtB1Fqs6YFNd11QPKoiRXn1J2Qu/lUxbFV7i8NBKMCKtia0n6/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu-surface": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/menu-surface": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/menu-surface/-/menu-surface-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-dMtSPN+olTWE+08M5qe4ea1IZOhVryYqzK0Gyb2u1G75rSArUxCOB5rr6OC/ST3Mq3RS6zGuYo7srZt4534K9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/notched-outline": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/notched-outline/-/notched-outline-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-WuurMg44xexkvLTBTnsO0A+qnzFjpcPdvgWBGstBepYozsvSF9zJGdb1x7Zv1MmqbpYh/Ohnuxtb/Y3jOh6irg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/floating-label": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/progress-indicator": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/progress-indicator/-/progress-indicator-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-uOnsvqw5F2fkeTnTl4MrYzjI7KCLmmLyZaM0cgLNuLsWVlddQE+SGMl28tENx7DUK3HebWq0FxCP8f25LuDD+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/radio": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/radio/-/radio-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-ehzOK+U1IxQN+OQjgD2lsnf1t7t7RAwQzeO6Czkiuid29ookYbQynWuLWk7NW8H8ohl7lnmfqTP1xSNkkL/F0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/ripple": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-JfLW+g3GMVDv4cruQ19+HUxpKVdWCldFlIPw1UYezz2h3WTNDy05S3uP2zUdXzZ01C3dkBFviv4nqZ0GCT16MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/rtl": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-SkKLNLFp5QtG7/JEFg9R92qq4MzTcZ5As6sWbH7rRg6ahTHoJEuqE+pOb9Vrtbj84k5gtX+vCYPvCILtSlr2uw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/segmented-button": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/segmented-button/-/segmented-button-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-YDwkCWP9l5mIZJ7pZJZ2hMDxfBlIGVJ+deNzr8O+Z7/xC5LGXbl4R5aPtUVHygvXAXxpf5096ZD+dSXzYzvWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/select": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/select/-/select-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-unfOWVf7T0sixVG+3k3RTuATfzqvCF6QAzA6J9rlCh/Tq4HuIBNDdV4z19IVu4zwmgWYxY0iSvqWUvdJJYwakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/floating-label": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/line-ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu-surface": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/notched-outline": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/shape": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/shape/-/shape-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Dsvr771ZKC46ODzoixLdGwlLEQLfxfLrtnRojXABoZf5G3o9KtJU+J+5Ld5aa960OAsCzzANuaub4iR88b1guA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/slider": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/slider/-/slider-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-3AEu+7PwW4DSNLndue47dh2u7ga4hDJRYmuu7wnJCIWJBnLCkp6C92kNc4Rj5iQY2ftJio5aj1gqryluh5tlYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/snackbar": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/snackbar/-/snackbar-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-TwwQSYxfGK6mc03/rdDamycND6o+1p61WNd7ElZv1F1CLxB4ihRjbCoH7Qo+oVDaP8CTpjeclka+24RLhQq0mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/icon-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/switch": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/switch/-/switch-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-OjUjtT0kRz1ASAsOS+dNzwMwvsjmqy5edK57692qmrP6bL4GblFfBDoiNJ6t0AN4OaKcmL5Hy/xNrTdOZW7Qqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "safevalues": "^0.3.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tab/-/tab-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-s/L9otAwn/pZwVQZBRQJmPqYeNbjoEbzbjMpDQf/VBG/6dJ+aP03ilIBEkqo8NVnCoChqcdtVCoDNRtbU+yp6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab-bar": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-bar/-/tab-bar-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Xmtq0wJGfu5k+zQeFeNsr4bUKv7L+feCmUp/gsapJ655LQKMXOUQZtSv9ZqWOfrCMy55hoF1CzGFV+oN3tyWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-scroller": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab-indicator": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-indicator/-/tab-indicator-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-despCJYi1GrDDq7F2hvLQkObHnSLZPPDxnOzU16zJ6FNYvIdszgfzn2HgAZ6pl5hLOexQ8cla6cAqjTDuaJBhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab-scroller": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-scroller/-/tab-scroller-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-QWHG/EWxirj4V9u2IHz+OSY9XCWrnNrPnNgEufxAJVUKV/A8ma1DYeFSQqxhX709R8wKGdycJksg0Flkl7Gq7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/textfield": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/textfield/-/textfield-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-R3qRex9kCaZIAK8DuxPnVC42R0OaW7AB7fsFknDKeTeVQvRcbnV8E+iWSdqTiGdsi6QQHifX8idUrXw+O45zPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/floating-label": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/line-ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/notched-outline": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/theme": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-CpUwXGE0dbhxQ45Hu9r9wbJtO/MAlv5ER4tBHA9tp/K+SU+lDgurBE2touFMg5INmdfVNtdumxb0nPPLaNQcUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tokens": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-nbEuGj05txWz6ZMUanpM47SaAD7soyjKILR+XwDell9Zg3bGhsnexCNXPEz2fD+YgomS+jM5XmIcaJJHg/H93Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0"
+      }
+    },
+    "node_modules/@material/tooltip": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tooltip/-/tooltip-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-UzuXp0b9NuWuYLYpPguxrjbJnCmT/Cco8CkjI/6JajxaeA3o2XEBbQfRMTq8PTafuBjCHTc0b0mQY7rtxUp1Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "safevalues": "^0.3.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/top-app-bar": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/top-app-bar/-/top-app-bar-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-vJWjsvqtdSD5+yQ/9vgoBtBSCvPJ5uF/DVssv8Hdhgs1PYaAcODUi77kdi0+sy/TaWyOsTkQixqmwnFS16zesA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/touch-target": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-AqYh9fjt+tv4ZE0C6MeYHblS2H+XwLbDl2mtyrK0DOEnCVQk5/l5ImKDfhrUdFWHvS4a5nBM4AA+sa7KaroLoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/typography": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-CKsG1zyv34AKPNyZC8olER2OdPII64iR2SzQjpqh1UUvmIFiMPk23LvQ1OnC5aCB14pOXzmVgvJt31r9eNdZ6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -10530,6 +11398,12 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "node_modules/safevalues": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/safevalues/-/safevalues-0.3.4.tgz",
+      "integrity": "sha512-LRneZZRXNgjzwG4bDQdOTSbze3fHm1EAKN/8bePxnlEZiBmkYEDggaHbuvHI9/hoqHbGfsEA7tWS9GhYHZBBsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/sass": {
       "version": "1.64.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@angular/compiler": "^16.2.0",
     "@angular/core": "^16.2.0",
     "@angular/forms": "^16.2.0",
+    "@angular/material": "^16.2.0",
     "@angular/platform-browser": "^16.2.0",
     "@angular/platform-browser-dynamic": "^16.2.0",
     "@angular/router": "^16.2.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
+    "deploy": "ng build --configuration production && npx angular-cli-ghpages --dir=dist/tech-plain",
     "test": "ng test"
   },
   "private": true,

--- a/prompt.md/prompt.md
+++ b/prompt.md/prompt.md
@@ -1,0 +1,39 @@
+Crie um projeto front-end utilizando o framework Angular 17 com Standalone Components.
+
+Siga os seguintes requisitos:
+
+1. **Estrutura de Código e Convenções**:
+   - Utilize a **mesma estrutura de pastas, arquitetura e configurações** do seguinte repositório como base:  
+     👉 [link do GitHub com a base do projeto (Datador/Event Publish)]
+   - Importe e configure da mesma forma: aliases, linting, environment, lazy loading, guards, interceptors, etc.
+
+2. **Componentes e Telas**:
+   - As telas devem ser desenvolvidas com base no seguinte design do Figma:  
+     🎨 [link do Figma com as telas do projeto]
+   - Cada tela deve ser criada como componente standalone, com roteamento configurado e divisão modular clara.
+
+3. **Design System**:
+   - Utilize o seguinte Design System para todos os componentes reutilizáveis (botões, inputs, modais, cards, etc.):  
+     📦 [link do design system]
+   - Caso algum componente do Figma **não exista no design system**, crie o componente manualmente utilizando **HTML + SCSS**, respeitando o estilo visual apresentado no Figma.
+
+4. **Boas Práticas**:
+   - Utilize Reactive Forms quando necessário.
+   - Tipagem 100% em TypeScript.
+   - Utilize Angular Material apenas se estiver especificado no design system.
+   - Código limpo, com nomes descritivos para variáveis, arquivos e pastas.
+   - Siga os princípios de responsabilidade única e componentização.
+
+5. **Extras (se possível)**:
+   - Configure o projeto para internacionalização (i18n).
+   - Adicione um README explicando como rodar e estruturar novos módulos.
+   - Adicione testes unitários para ao menos 2 componentes e 1 serviço.
+
+---
+
+🔧 Me entregue o projeto final com:
+- Estrutura de pastas igual ao repo.
+- Todos os componentes/telas do Figma convertidos.
+- Componentes customizados quando não existir no design system.
+- Documentação técnica (README.md).
+

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -5,19 +5,13 @@
 ></app-home> -->
 
 <ng-container *ngIf="isFlowActive">
-  <app-sidebar
-    [flowType]="flowType"
-    (routeClicked)="onRouteClicked($event)"
-    (isMinimizedClicked)="isMinimized = $event"
-  >
+  <app-sidebar [flowType]="flowType" (routeClicked)="onRouteClicked($event)"
+    (isMinimizedClicked)="isMinimized = $event">
   </app-sidebar>
-  <div
-    class="main-content"
-    [class.minimized]="isMinimized"
-    [ngSwitch]="currentRoute"
-  >
-    <app-dashboard *ngSwitchCase="'dashboard'" >
-      <app-custom-filter [flowType]="flowType" filter [showPriority]="false" [selectedFilter]="filter"></app-custom-filter>
+  <div class="main-content" [class.minimized]="isMinimized" [ngSwitch]="currentRoute">
+    <app-dashboard *ngSwitchCase="'dashboard'">
+      <app-custom-filter [flowType]="flowType" filter [showPriority]="false"
+        [selectedFilter]="filter"></app-custom-filter>
     </app-dashboard>
     <app-allocations *ngSwitchCase="'allocations'" [flowType]="flowType">
       <app-custom-filter [flowType]="flowType" filter [showPriority]="false"></app-custom-filter>
@@ -28,6 +22,9 @@
     <app-activity-log *ngSwitchCase="'activities'" [flowType]="flowType">
       <app-custom-filter [flowType]="flowType" filter></app-custom-filter>
     </app-activity-log>
-    <app-tablet-tasks *ngSwitchCase="'tablet'"></app-tablet-tasks>
+    <app-plan-day *ngSwitchCase="'planDay'">
+      <app-custom-filter [flowType]="flowType" filter></app-custom-filter>
+
+    </app-plan-day>
   </div>
 </ng-container>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -28,5 +28,6 @@
     <app-activity-log *ngSwitchCase="'activities'" [flowType]="flowType">
       <app-custom-filter [flowType]="flowType" filter></app-custom-filter>
     </app-activity-log>
+    <app-tablet-tasks *ngSwitchCase="'tablet'"></app-tablet-tasks>
   </div>
 </ng-container>

--- a/src/app/core/components/sidebar/sidebar.component.html
+++ b/src/app/core/components/sidebar/sidebar.component.html
@@ -32,7 +32,7 @@
         <span *ngIf="!isMinimized">Quadro Kanban</span>
       </a>
     </li>
-    <li>
+    <!-- <li>
       <a
         (click)="navigate('activities')"
         [class.active]="activeRoute === 'activities'"
@@ -40,14 +40,14 @@
         <span class="icon">✅</span>
         <span *ngIf="!isMinimized">Atividades</span>
       </a>
-    </li>
+    </li> -->
     <li>
       <a
-        (click)="navigate('tablet')"
-        [class.active]="activeRoute === 'tablet'"
+        (click)="navigate('planDay')"
+        [class.active]="activeRoute === 'planDay'"
       >
-        <span class="icon">📱</span>
-        <span *ngIf="!isMinimized">Tablet</span>
+        <span class="icon">🗓️</span>
+        <span *ngIf="!isMinimized">Meu Dia</span>
       </a>
     </li>
   </ul>

--- a/src/app/core/components/sidebar/sidebar.component.html
+++ b/src/app/core/components/sidebar/sidebar.component.html
@@ -41,5 +41,14 @@
         <span *ngIf="!isMinimized">Atividades</span>
       </a>
     </li>
+    <li>
+      <a
+        (click)="navigate('tablet')"
+        [class.active]="activeRoute === 'tablet'"
+      >
+        <span class="icon">📱</span>
+        <span *ngIf="!isMinimized">Tablet</span>
+      </a>
+    </li>
   </ul>
 </nav>

--- a/src/app/features/activity-log/page/activity-log.component.ts
+++ b/src/app/features/activity-log/page/activity-log.component.ts
@@ -125,8 +125,10 @@ export class ActivityLogComponent
   //ok
   loadData() {
     this.taskService.getAllTasks().then((response) => {
-      this.data = response;
-      this.dataBackup = response;
+      this.data = response
+        .filter((task) => task.status !== 'Done')
+      this.dataBackup = response
+        .filter((task) => task.status !== 'Done')
     });
   }
 

--- a/src/app/features/features.module.ts
+++ b/src/app/features/features.module.ts
@@ -6,7 +6,7 @@ import { ActivityLogComponent } from './activity-log/page/activity-log.component
 import { AllocationsComponent } from './allocations/allocations.component';
 import { HomeComponent } from './home/home.component';
 import { FilterCardComponent } from './home/components/filter-card/filter-card.component';
-import { TabletTasksComponent } from './tablet-tasks/page/tablet-tasks.component';
+import { PlanDayComponent } from './plan-day/pages/plan-day/plan-day.component';
 
 const COMPONENTS = [
   DashboardComponent,
@@ -15,7 +15,7 @@ const COMPONENTS = [
   AllocationsComponent,
   HomeComponent,
   FilterCardComponent,
-  TabletTasksComponent
+  PlanDayComponent
 ];
 
 @NgModule({

--- a/src/app/features/features.module.ts
+++ b/src/app/features/features.module.ts
@@ -6,6 +6,7 @@ import { ActivityLogComponent } from './activity-log/page/activity-log.component
 import { AllocationsComponent } from './allocations/allocations.component';
 import { HomeComponent } from './home/home.component';
 import { FilterCardComponent } from './home/components/filter-card/filter-card.component';
+import { TabletTasksComponent } from './tablet-tasks/page/tablet-tasks.component';
 
 const COMPONENTS = [
   DashboardComponent,
@@ -13,7 +14,8 @@ const COMPONENTS = [
   ActivityLogComponent,
   AllocationsComponent,
   HomeComponent,
-  FilterCardComponent
+  FilterCardComponent,
+  TabletTasksComponent
 ];
 
 @NgModule({

--- a/src/app/features/kanban/models/kanban.models.ts
+++ b/src/app/features/kanban/models/kanban.models.ts
@@ -2,7 +2,9 @@ export interface Task {
   id: string;
   title: string;
   description: string;
-  priority: string
+  priority: string,
+  tasks: []
+
 }
 
 export interface Column {

--- a/src/app/features/kanban/page/kanban.component.html
+++ b/src/app/features/kanban/page/kanban.component.html
@@ -44,7 +44,7 @@
   </div>
 </div>
 
-<div class="modal" [ngClass]="{ show: isModalOpen }">
+<!-- <div class="modal" [ngClass]="{ show: isModalOpen }">
   <div class="modal-content">
     <span class="close-button" (click)="closeModal()">&times;</span>
     <h3>{{ isEditing ? "Editar Atividade" : "Nova Atividade" }}</h3>
@@ -174,6 +174,196 @@
         class="form-buttons"
         *ngIf="activityForm.get('status')?.value !== 'Done'"
       >
+        <button type="submit" class="save-button">
+          {{ isEditing ? "Atualizar" : "Salvar" }} Atividade
+        </button>
+        <button
+          type="button"
+          class="delete-button"
+          *ngIf="isEditing"
+          (click)="deleteActivity(editActivityId!)"
+        >
+          Excluir
+        </button>
+      </div>
+    </form>
+  </div>
+</div> -->
+
+<div class="modal" [ngClass]="{ show: isModalOpen }">
+  <div class="modal-content">
+    <span class="close-button" (click)="closeModal()">&times;</span>
+    <h3>{{ isEditing ? "Editar Atividade" : "Nova Atividade" }}</h3>
+    <hr />
+    <form class="grid-form" [formGroup]="activityForm" (ngSubmit)="onSubmit()">
+      <div class="form-group">
+        <label for="title">Título</label>
+        <input
+          type="text"
+          id="title"
+          formControlName="title"
+          placeholder="Título"
+        />
+      </div>
+
+      <div class="form-group">
+        <label for="description">Descrição</label>
+        <input
+          type="text"
+          id="description"
+          formControlName="description"
+          placeholder="Descrição"
+        />
+      </div>
+
+      <div class="form-group">
+        <label for="priority">priority</label>
+        <select
+          id="priority"
+          name="priority"
+          required
+          formControlName="priority"
+        >
+          <option value="">Selecione a prioridade</option>
+          <option *ngFor="let priority of prioridades" [value]="priority">
+            {{ priority }}
+          </option>
+        </select>
+      </div>
+
+      <div class="form-group">
+        <label for="status">Status</label>
+        <select id="status" formControlName="status">
+          <option value="">Selecione o Status</option>
+          <option value="To Do">To Do</option>
+          <option value="In Progress">In Progress</option>
+          <option value="Review">Review</option>
+          <option value="Done">Done</option>
+        </select>
+      </div>
+
+      <div class="form-group">
+        <label for="release">Release</label>
+        <select
+          id="release"
+          formControlName="release"
+        >
+          <option value="">Selecione a Release</option>
+          <option *ngFor="let release of releases" [value]="release">
+            {{ release }}
+          </option>
+        </select>
+      </div>
+
+      <div class="form-group">
+        <label for="sprint">Sprint</label>
+        <select
+          id="sprint"
+          formControlName="sprint"
+        >
+          <option value="">Selecione a Sprint</option>
+          <option *ngFor="let sprint of sprints" [value]="sprint">
+            {{ sprint }}
+          </option>
+        </select>
+      </div>
+
+      <div class="form-group">
+        <label for="squad">Squad</label>
+        <select
+          id="squad"
+          name="squad"
+          required
+          formControlName="squad"
+          (ngModelChange)="onSquadChange($event)"
+        >
+          <option value="">Selecione a Squad</option>
+          <option *ngFor="let squad of squads" [value]="squad">
+            {{ squad }}
+          </option>
+        </select>
+      </div>
+
+      <div class="form-group">
+        <label for="employeeName">Colaborador</label>
+        <select
+          id="employeeName"
+          name="employeeName"
+          required
+          formControlName="employeeName"
+        >
+          <option value="">Selecione o Colaborador</option>
+          <option *ngFor="let member of members" [value]="member">
+            {{ member }}
+          </option>
+        </select>
+      </div>
+
+      <div class="form-group">
+        <label for="allocatedHours">Horas Atividade</label>
+        <input
+          type="number"
+          id="allocatedHours"
+          formControlName="allocatedHours"
+          placeholder="Horas Atividade"
+          min="0"
+        />
+      </div>
+      <!-- <div class="form-group">
+        <label for="totalAllocatedHours"
+          >Horas Totais Alocadas para Squad</label
+        >
+        <input
+          type="number"
+          disabled
+          id="totalAllocatedHours"
+          [value]="totalAllocatedHours"
+        />
+      </div> -->
+
+      <!-- <div class="form-group">
+        <label for="spentHours">Horas Sobrando</label>
+        <input
+          disabled
+          type="number"
+          id="spentHours"
+          placeholder="Horas Gastas"
+          [value]="totalSpentAllocatedHours"
+        />
+      </div> -->
+
+      <!-- NOVA SEÇÃO: Cadastro de tarefas dentro da história -->
+      <div class="form-group tasks-section" formArrayName="tasks">
+        <h4>Tarefas da História</h4>
+        <div
+          *ngFor="let task of tasks.controls; let i = index"
+          [formGroupName]="i"
+          class="task-group"
+        >
+          <div class="form-group">
+            <label>Título da Tarefa</label>
+            <input
+              type="text"
+              formControlName="title"
+              placeholder="Título da Tarefa"
+            />
+          </div>
+          <div class="form-group">
+            <label>Descrição da Tarefa</label>
+            <input
+              type="text"
+              formControlName="description"
+              placeholder="Descrição da Tarefa"
+            />
+          </div>
+          <button type="button" (click)="removeTask(i)">Remover Tarefa</button>
+        </div>
+        <div class="add-task-button">
+          <button type="button" (click)="addTask()">Adicionar Tarefa</button>
+        </div>
+      </div>
+
+      <div class="form-buttons">
         <button type="submit" class="save-button">
           {{ isEditing ? "Atualizar" : "Salvar" }} Atividade
         </button>

--- a/src/app/features/kanban/page/kanban.component.scss
+++ b/src/app/features/kanban/page/kanban.component.scss
@@ -113,15 +113,16 @@
 }
 
 .modal-content {
-  background: white;
-  padding: 20px;
-  border-radius: 8px;
-  width: 80%;
+  background: #fff;
+  padding: 30px;
+  border-radius: 10px;
+  width: 90%;
   max-width: 600px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
   position: relative;
 }
-
 .close-button {
   position: absolute;
   top: 10px;
@@ -135,6 +136,7 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 20px;
+  margin-top: 20px;
 }
 
 .grid-form .form-group {
@@ -143,33 +145,47 @@
 }
 
 .grid-form .form-group label {
-  font-weight: bold;
+  font-weight: 600;
   margin-bottom: 5px;
+  color: #333;
 }
 
 .grid-form .form-group input,
-.grid-form .form-group select {
-  padding: 8px;
+.grid-form .form-group select,
+.grid-form .form-group textarea {
+  padding: 10px;
   border: 1px solid #ccc;
-  border-radius: 4px;
+  border-radius: 6px;
+  font-size: 1rem;
+  transition: border-color 0.3s ease;
+}
+
+.grid-form .form-group input:focus,
+.grid-form .form-group select:focus,
+.grid-form .form-group textarea:focus {
+  outline: none;
+  border-color: #3498db;
 }
 
 .grid-form .form-buttons {
   grid-column: span 2;
-  text-align: center;
   display: flex;
   justify-content: space-between;
-  gap: 10px;
+  margin-top: 20px;
+}
+
+.save-button,
+.delete-button {
+  padding: 12px 24px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.3s ease;
 }
 
 .save-button {
-  padding: 10px 20px;
   background: #4CAF50;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: background 0.3s;
+  color: #fff;
 }
 
 .save-button:hover {
@@ -177,18 +193,84 @@
 }
 
 .delete-button {
-  padding: 10px 20px;
   background: #f44336;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: background 0.3s;
+  color: #fff;
 }
 
 .delete-button:hover {
   background: #d32f2f;
 }
+
+.tasks-section {
+  grid-column: span 2;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 15px;
+  margin-top: 20px;
+  background: #f9f9f9;
+}
+
+.modal hr {
+  border: none;
+  border-top: 1px solid #eee;
+  margin: 10px 0;
+}
+
+.tasks-section h4 {
+  margin-bottom: 15px;
+  font-size: 1.2em;
+  color: #333;
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 5px;
+}
+
+.task-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 15px;
+  background: #fff;
+  padding: 10px;
+  border-radius: 6px;
+  border: 1px solid #e0e0e0;
+}
+
+.task-group button {
+  align-self: flex-end;
+  background: #f44336;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 5px 10px;
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.task-group button:hover {
+  background: #d32f2f;
+}
+
+
+.add-task-button {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 20px;
+}
+
+.add-task-button button {
+  padding: 10px 20px;
+  background: #3498db;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.add-task-button button:hover {
+  background: #2980b9;
+}
+
 
 @media (max-width: 768px) {
   .kanban-board {

--- a/src/app/features/plan-day/pages/plan-day/plan-day.component.html
+++ b/src/app/features/plan-day/pages/plan-day/plan-day.component.html
@@ -1,0 +1,32 @@
+<div class="container">
+  <h1>Planejamento do dia</h1>
+  <div class="filter-container">
+    <div class="filter-group">
+      <ng-content select="[filter]"> </ng-content>
+    </div>
+  </div>
+
+  <!-- <label for="sortMode">Sort by:</label>
+  <select id="sortMode" [(ngModel)]="sortMode" (change)="onSortChange()">
+    <option value="manual">Manual</option>
+    <option value="priority-desc">Prioridade: Alta → Baixa</option>
+    <option value="priority-asc">Prioridade: Baixa → Alta</option>
+  </select> -->
+
+  <div cdkDropList (cdkDropListDropped)="drop($event)">
+    <div *ngFor="let task of dataPlan">
+      <div class="card" *ngFor="let value of task" cdkDrag>
+        <div class="handle">☰</div>
+        <div>
+          <h3>{{ value.title }}</h3>
+          <p>{{ value.description }}</p>
+          <!-- <p *ngIf="task.status">{{ task.status }}</p> -->
+        </div>
+        <!-- <span class="tag" [ngClass]="task.priority.toLowerCase()">
+          {{ task.priority }}
+        </span> -->
+        <span></span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/features/plan-day/pages/plan-day/plan-day.component.scss
+++ b/src/app/features/plan-day/pages/plan-day/plan-day.component.scss
@@ -1,0 +1,112 @@
+.container {
+  // max-width: 500px;
+  margin: auto;
+  padding: 2rem;
+  background: #f8fafc;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  text-align: center;
+
+  h1 {
+    font-size: 1.8rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .subtitle {
+    color: #6b7280;
+    margin-bottom: 1.5rem;
+  }
+
+  .card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem;
+    margin-bottom: 0.75rem;
+    border-radius: 10px;
+    background: white;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
+    transition: all 0.2s ease;
+
+    h3 {
+      margin: 0;
+      font-size: 1.1rem;
+    }
+
+    p {
+      margin: 0.25rem 0 0;
+      color: #4b5563;
+      font-size: 0.9rem;
+    }
+
+    .handle {
+      cursor: grab;
+      margin-right: 10px;
+      font-size: 1.2rem;
+      color: #9ca3af;
+      width: 50px;
+
+      input {
+        width: 50px;
+      }
+    }
+
+    .tag {
+      font-size: 0.75rem;
+      padding: 0.3rem 0.6rem;
+      border-radius: 6px;
+      color: white;
+
+      &.alta {
+        background: #ef4444;
+      }
+
+      &.média {
+        background: #f59e0b;
+      }
+
+      &.baixa {
+        background: #22c55e;
+      }
+    }
+  }
+
+  button {
+    margin-top: 1.5rem;
+    background-color: #2563eb;
+    color: white;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    border-radius: 8px;
+    font-size: 1rem;
+    cursor: pointer;
+
+    &:hover {
+      background-color: #1d4ed8;
+    }
+  }
+}
+
+
+::ng-deep .cdk-drag-preview {
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+  border-radius: 10px;
+  background: white;
+  padding: 1rem;
+  width: 100%;
+  z-index: 1000;
+}
+
+::ng-deep .cdk-drag-placeholder {
+  opacity: 0;
+}
+::ng-deep .cdk-drag-preview {
+  @extend .card; // se usar SCSS
+}
+::ng-deep .cdk-drag-preview h3,
+::ng-deep .cdk-drag-preview p {
+  margin: 0;
+  word-break: break-word;
+  white-space: normal;
+}
+

--- a/src/app/features/plan-day/pages/plan-day/plan-day.component.spec.ts
+++ b/src/app/features/plan-day/pages/plan-day/plan-day.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PlanDayComponent } from './plan-day.component';
+
+describe('PlanDayComponent', () => {
+  let component: PlanDayComponent;
+  let fixture: ComponentFixture<PlanDayComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [PlanDayComponent]
+    });
+    fixture = TestBed.createComponent(PlanDayComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/plan-day/pages/plan-day/plan-day.component.ts
+++ b/src/app/features/plan-day/pages/plan-day/plan-day.component.ts
@@ -1,0 +1,141 @@
+import { Component, ContentChild, OnInit } from '@angular/core';
+import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
+import { TaskService } from '@indexeddb/services/task/task.service';
+import { CustomFilterComponent } from 'src/app/core/components/custom-filter/custom-filter.component';
+import { BaseFilterableComponent } from '@components/base/base-filterable.components';
+import { ITaskBoard } from '@indexeddb/models/indexeddb.model';
+import {
+  PRIORITIES,
+  RELEASES,
+  SPRINTS,
+  SQUAD_MEMBERS,
+} from '@constants/squad.constants';
+
+interface Task {
+  title: string;
+  description?: string;
+  priority: 'High' | 'Medium' | 'Low';
+  order?: number;
+}
+
+@Component({
+  selector: 'app-plan-day',
+  templateUrl: './plan-day.component.html',
+  styleUrls: ['./plan-day.component.scss'],
+})
+export class PlanDayComponent
+  extends BaseFilterableComponent<ITaskBoard>
+  implements OnInit
+{
+  @ContentChild(CustomFilterComponent) filter!: CustomFilterComponent;
+
+  tasks: Task[] = [
+    { title: 'Azure Authentication', description: 'Torre', priority: 'High' },
+    { title: 'MFE List and Detail', priority: 'High' },
+    {
+      title: 'NSMC Analysis',
+      description: 'Analyze connection with native journeys and output process',
+      priority: 'High',
+    },
+    { title: 'Malote Pilot', description: 'Follow pilot', priority: 'Low' },
+  ];
+
+  members: string[] = [];
+  sprints = SPRINTS;
+  releases = RELEASES;
+  squads = Object.keys(SQUAD_MEMBERS);
+  prioridades = PRIORITIES;
+  dataPlan: any;
+
+  constructor(private taskService: TaskService) {
+    super();
+  }
+
+  ngOnInit(): void {
+    this.loadData();
+  }
+
+  ngAfterContentInit(): void {
+    if (this.filter) {
+      this.filter.filterChangeEmmiter.subscribe((event) => {
+        this.onFilterChange(event.value, event.event);
+      });
+      this.filter.cleanFilterEmitter.subscribe((isCleanFilter) => {
+        if (isCleanFilter) {
+          this.onCleanFilter();
+        }
+      });
+    }
+  }
+  override onCleanFilter() {
+    super.onCleanFilter();
+    this.createTaks(this.data);
+  }
+
+  override onFilterChange(newValue: string, type: string): void {
+    super.onFilterChange(newValue, type);
+    this.createTaks(this.data);
+  }
+
+  drop(event: CdkDragDrop<Task[]>) {
+    moveItemInArray(this.dataPlan, event.previousIndex, event.currentIndex);
+    this.updateTaskOrder(); // atualiza os campos "order"
+  }
+
+  updateTaskOrder() {
+    this.dataPlan.forEach((task: Task, index: number) => {
+      task.order = index;
+    });
+  }
+
+  saveDayPlan() {
+    console.log('Day plan saved:', this.tasks);
+    // Optionally send to backend
+  }
+
+  onSortChange() {
+    if (this.sortMode === 'priority-desc') {
+      this.dataPlan.sort(
+        (a: Task, b: Task) =>
+          this.priorityWeight(a.priority) - this.priorityWeight(b.priority)
+      );
+    } else if (this.sortMode === 'priority-asc') {
+      this.dataPlan.sort(
+        (a: Task, b: Task) =>
+          this.priorityWeight(b.priority) - this.priorityWeight(a.priority)
+      );
+    }
+    this.updateTaskOrder(); // sempre atualiza os campos `order`
+  }
+  priorityWeight(priority: string): number {
+    const map = { High: 1, Medium: 2, Low: 3 };
+    return map[priority as keyof typeof map] || 4;
+  }
+
+  sortMode: 'manual' | 'priority-asc' | 'priority-desc' = 'manual';
+
+  loadData() {
+    // this.taskService.getAllTasks().then((response) => {
+    //   this.dataPlan = response.filter((data) => data.status !== 'Done');
+    //   console.log('this.dataPlan:', this.dataPlan);
+    // });
+
+    this.taskService.getAllTasks().then((response) => {
+      this.data = response;
+      this.dataBackup = response;
+      this.createTaks(response);
+    });
+  }
+
+  createTaks(response: ITaskBoard[]) {
+    console.log('response: ', response);
+    this.dataPlan = response
+      .filter((task) => task.status !== 'Done')
+      .filter((value) => value.status !== 'To Do')
+      .map((task) => (task.tasks))
+    console.log("tasks: ", this.dataPlan  )
+    this.dataPlan.sort(
+      (a: { order: number }, b: { order: number }) => a.order - b.order
+    );
+  }
+}

--- a/src/app/features/tablet-tasks/page/tablet-tasks.component.html
+++ b/src/app/features/tablet-tasks/page/tablet-tasks.component.html
@@ -1,5 +1,5 @@
 <div class="tasks-grid">
-  <div class="task-square" *ngFor="let task of tasks">
+  <div class="task-square" *ngFor="let task of exampleTasks">
     <h3>{{ task.title }}</h3>
     <p>{{ task.description }}</p>
   </div>

--- a/src/app/features/tablet-tasks/page/tablet-tasks.component.html
+++ b/src/app/features/tablet-tasks/page/tablet-tasks.component.html
@@ -1,0 +1,6 @@
+<div class="tasks-grid">
+  <div class="task-square" *ngFor="let task of tasks">
+    <h3>{{ task.title }}</h3>
+    <p>{{ task.description }}</p>
+  </div>
+</div>

--- a/src/app/features/tablet-tasks/page/tablet-tasks.component.scss
+++ b/src/app/features/tablet-tasks/page/tablet-tasks.component.scss
@@ -1,8 +1,8 @@
 .tasks-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 16px;
-  padding: 16px;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 24px;
+  padding: 24px;
   height: 100vh;
   box-sizing: border-box;
 }
@@ -16,6 +16,6 @@
   justify-content: center;
   align-items: center;
   aspect-ratio: 1 / 1;
-  padding: 8px;
+  padding: 16px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }

--- a/src/app/features/tablet-tasks/page/tablet-tasks.component.scss
+++ b/src/app/features/tablet-tasks/page/tablet-tasks.component.scss
@@ -1,0 +1,21 @@
+.tasks-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 16px;
+  padding: 16px;
+  height: 100vh;
+  box-sizing: border-box;
+}
+
+.task-square {
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  aspect-ratio: 1 / 1;
+  padding: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}

--- a/src/app/features/tablet-tasks/page/tablet-tasks.component.spec.ts
+++ b/src/app/features/tablet-tasks/page/tablet-tasks.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TabletTasksComponent } from './tablet-tasks.component';
+
+describe('TabletTasksComponent', () => {
+  let component: TabletTasksComponent;
+  let fixture: ComponentFixture<TabletTasksComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TabletTasksComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TabletTasksComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/tablet-tasks/page/tablet-tasks.component.ts
+++ b/src/app/features/tablet-tasks/page/tablet-tasks.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { v4 as uuidv4 } from 'uuid';
 import { ITaskBoard } from '@indexeddb/models/indexeddb.model';
 import { TaskService } from '@indexeddb/services/task/task.service';
 
@@ -10,9 +11,51 @@ import { TaskService } from '@indexeddb/services/task/task.service';
 export class TabletTasksComponent implements OnInit {
   tasks: ITaskBoard[] = [];
 
+  private exampleTasks: ITaskBoard[] = [
+    {
+      id: uuidv4(),
+      title: 'Tarefa 1',
+      description: 'Primeira tarefa de exemplo',
+      status: 'To Do',
+      sprint: 'Sprint 1',
+      release: 'R1',
+      allocatedHours: 0,
+      spentHours: 0,
+      employeeName: 'Usuário',
+      createdDate: new Date(),
+      updatedDate: new Date(),
+      squad: 'S1',
+      priority: 'Baixa',
+      tasks: [],
+    },
+    {
+      id: uuidv4(),
+      title: 'Tarefa 2',
+      description: 'Segunda tarefa de exemplo',
+      status: 'In Progress',
+      sprint: 'Sprint 1',
+      release: 'R1',
+      allocatedHours: 0,
+      spentHours: 0,
+      employeeName: 'Usuário',
+      createdDate: new Date(),
+      updatedDate: new Date(),
+      squad: 'S1',
+      priority: 'Média',
+      tasks: [],
+    },
+  ];
+
   constructor(private taskService: TaskService) {}
 
   ngOnInit(): void {
-    this.taskService.getAllTasks().then((tasks) => (this.tasks = tasks));
+    this.taskService.getAllTasks().then((tasks) => {
+      if (tasks.length === 0) {
+        this.exampleTasks.forEach((t) => this.taskService.addTask(t));
+        this.tasks = this.exampleTasks;
+      } else {
+        this.tasks = tasks;
+      }
+    });
   }
 }

--- a/src/app/features/tablet-tasks/page/tablet-tasks.component.ts
+++ b/src/app/features/tablet-tasks/page/tablet-tasks.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit } from '@angular/core';
+import { ITaskBoard } from '@indexeddb/models/indexeddb.model';
+import { TaskService } from '@indexeddb/services/task/task.service';
+
+@Component({
+  selector: 'app-tablet-tasks',
+  templateUrl: './tablet-tasks.component.html',
+  styleUrls: ['./tablet-tasks.component.scss'],
+})
+export class TabletTasksComponent implements OnInit {
+  tasks: ITaskBoard[] = [];
+
+  constructor(private taskService: TaskService) {}
+
+  ngOnInit(): void {
+    this.taskService.getAllTasks().then((tasks) => (this.tasks = tasks));
+  }
+}

--- a/src/app/features/tablet-tasks/page/tablet-tasks.component.ts
+++ b/src/app/features/tablet-tasks/page/tablet-tasks.component.ts
@@ -11,7 +11,7 @@ import { TaskService } from '@indexeddb/services/task/task.service';
 export class TabletTasksComponent implements OnInit {
   tasks: ITaskBoard[] = [];
 
-  private exampleTasks: ITaskBoard[] = [
+  exampleTasks: ITaskBoard[] = [
     {
       id: uuidv4(),
       title: 'Tarefa 1',

--- a/src/app/shared/components/base/base-filterable.components.ts
+++ b/src/app/shared/components/base/base-filterable.components.ts
@@ -43,7 +43,6 @@ export abstract class BaseFilterableComponent<T extends TaskFilter> {
    * Se todos os filtros estiverem em "Todos", chama o método loadData() para recarregar os dados.
    */
   onFilterChange(newValue: string, type: string): void {
-    console.log('entrouuu');
     switch (type) {
       case 'member':
         this.selectedMember = newValue;

--- a/src/app/shared/constants/squad.constants.ts
+++ b/src/app/shared/constants/squad.constants.ts
@@ -17,8 +17,6 @@ export const SQUAD_MEMBERS: Record<SquadKey, string[]> = {
 
 export const CROSS_MEMBERS = [
   'Italo Silvestre',
-  'Luiz Arquiteto',
-  'Gabriel UX',
 ];
 export const SPRINTS = ['S1', 'S2', 'S3', 'S4'];
 export const RELEASES = ['R1', 'R2', 'R3', 'R4'];

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -3,7 +3,6 @@ import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { DragDropModule } from '@angular/cdk/drag-drop';
-import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
 const COMMON_COMPONENTS = [
   FormsModule,
@@ -11,9 +10,7 @@ const COMMON_COMPONENTS = [
   BrowserAnimationsModule,
   ReactiveFormsModule,
   DragDropModule,
-  FontAwesomeModule
 ];
-
 
 @NgModule({
   declarations: [],


### PR DESCRIPTION
## Summary
- add TabletTasksComponent and grid-based view
- export TabletTasksComponent from FeaturesModule
- provide route switch and sidebar menu to view tasks on tablets
- disable Angular analytics in angular.json

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_6840f43c5d4883319329e3bfa07b50bf